### PR TITLE
Add custom re(gex)/rep(lacement) config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-bot.conf
+*.conf

--- a/bot.conf.example
+++ b/bot.conf.example
@@ -7,3 +7,5 @@ ignore   = trumpetbot,abusiveuser
 password = pleffquiffle
 admins   = snargle!~kleg@glarg.example.com
 must_id  = 1
+re      = tr+u, l+e+n+y
+rep     = 🎺, ( ͡° ͜ʖ ͡°)

--- a/saxrobot
+++ b/saxrobot
@@ -88,6 +88,17 @@ sub irc_public {
 	if ($saxcount > 0) {
 		$irc->yield(privmsg => $channel => "🎷 " x $saxcount);
 	}
+
+	my $idx = 0;
+	for (@{$config{re}}) {
+		my $repcount = () = $what =~ /@{$config{re}}[$idx]/gi;
+		if ($repcount > 0) {
+		if ($repcount > 0) {
+			$irc->yield(privmsg => $channel => @{$config{rep}}[$idx] x $repcount);
+		}
+		$idx++;
+	}
+
 	return;
 }
 

--- a/sb_config.pm
+++ b/sb_config.pm
@@ -9,7 +9,7 @@ use Config::Tiny;
 sub parse_config
 {
 	my @scalar_configs = ('nick', 'username', 'ircname', 'server', 'port', 'password', 'must_id');
-	my @list_configs = ('channels', 'ignore', 'admins');
+	my @list_configs = ('channels', 'ignore', 'admins', 're', 'rep' );
 	my $file = $_[0];
 	my %built_config;
 	my $config = Config::Tiny->read($file);


### PR DESCRIPTION
Added `$config{re}/$config{rep}` list configuration options.

`@{$config{re}}` is a list of regexes to scan IRC chat for.
`@{$config{rep}} `is a list of replacement strings, where the string to be replaced shares indices with it's respective regex.

In the example config:
```
re      = tr+u, l+e+n+y
rep     = 🎺, ( ͡° ͜ʖ ͡°)
```
When `@{$config{re}}[0]` ( which in this instance happens to be **"/tr+u/"** ) is found, it is replaced by it's respective string `@{$config{re}}[0]` ( which in this instance is **"🎺"**).

Whereas when the `@{$config{re}}[1]` regex ( which for this example happens to be **"/l+e+n+y/"** ) is found, it is replaced by it's respective string `@{$config{re}}[1]` ( which in this example is **"( ͡° ͜ʖ ͡°)"**).